### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["master", "main"]
 
+permissions:
+  contents: read
+
 jobs:
   format-and-lint:
     name: Check Formatting and Linting

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -25,7 +25,7 @@ jobs:
           deno install
       - name: Check format
         run: |
-          deno fmt
+          deno fmt .
           git --no-pager diff --exit-code --color=never
       - name: Check lint
         run: |

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,13 +1,13 @@
 name: Deno Formatting and Linting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master", "main"]
   pull_request:
     branches: ["master", "main"]
-
-permissions:
-  contents: read
 
 jobs:
   format-and-lint:


### PR DESCRIPTION
Potential fix for [https://github.com/Wissididom/GreasyFork-Scripts/security/code-scanning/1](https://github.com/Wissididom/GreasyFork-Scripts/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block for the workflow or for the specific job, restricting the `GITHUB_TOKEN` to the least privileges required. For this workflow, the job only needs to read repository contents (for checkout) and does not interact with PRs, issues, or other resources, so `contents: read` is sufficient.

The best fix with no behavior change is to add a `permissions:` block at the workflow root level so it applies to all jobs. This should be added just after the `on:` block (e.g., between line 7 and line 9). The block should set `contents: read`. No imports or additional methods are needed, as this is purely a YAML configuration change. After the change, CodeQL will recognize that the workflow limits the `GITHUB_TOKEN` scope appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
